### PR TITLE
Python3 support, building on CentOS 8 and 9.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  # XXX done outside of the matrix due to different container name
+  # XXX done outside of the build matrix due to different container name
   build-centos7:
     name: Build CentOS 7 RPMs
     runs-on: ubuntu-latest
@@ -28,24 +28,6 @@ jobs:
           name: rpms7
           path: |
             build/RPMS/noarch/glite-info-static-*.el7.noarch.rpm
-  install-centos7:
-    name: Install CentOS 7 RPMs
-    needs: build-centos7
-    runs-on: ubuntu-latest
-    container: quay.io/centos/centos:7
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: rpms7
-      - name: Install generated RPMs
-        run: |
-          yum localinstall -y glite-info-static-*.el7.noarch.rpm
-      - name: Test installed RPMs
-        run: |
-          curl https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo > /etc/yum.repos.d/EGI-trustanchors.repo
-          yum install -y ca-policy-egi-core
-          echo 'capath = /etc/grid-security/certificates' >> /etc/glite/glite-info-static.conf
-          glite-info-static -v -c /etc/glite/glite-info-static.conf
 
   # Use a matrix for CentOS Stream versions
   build:
@@ -73,18 +55,53 @@ jobs:
           name: rpms${{ matrix.centos-version }}
           path: |
             build/RPMS/noarch/glite-info-static-*.el${{ matrix.centos-version }}.noarch.rpm
-  install:
-    strategy:
-      matrix:
-        centos-version: [8, 9]
-    name: Install CentOS ${{ matrix.centos-version }} RPMs
-    needs: build
+
+  install-centos7:
+    name: Install CentOS 7 RPMs
+    needs: build-centos7
     runs-on: ubuntu-latest
-    container: quay.io/centos/centos:stream${{ matrix.centos-version }}
+    container: quay.io/centos/centos:7
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: rpms${{ matrix.centos-version }}
+          name: rpms7
       - name: Install generated RPMs
         run: |
-          yum localinstall -y glite-info-static-*.el${{ matrix.centos-version }}.noarch.rpm
+          yum localinstall -y glite-info-static-*.el7.noarch.rpm
+      - name: Test installed RPMs
+        run: |
+          curl https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo > /etc/yum.repos.d/EGI-trustanchors.repo
+          yum install -y ca-policy-egi-core
+          mkdir -p /etc/glite
+          echo 'capath = /etc/grid-security/certificates' >> /etc/glite/glite-info-static.conf
+          glite-info-static -v -c /etc/glite/glite-info-static.conf
+
+  # Dependency from PowerTools: openldap-servers
+  centos8-install:
+    name: Install CentOS Stream 8 RPMs
+    needs: build
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream8
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: rpms8
+      - name: Install generated RPMs
+        run: |
+          sed -i 's/^enabled=0/enabled=1/' /etc/yum.repos.d/CentOS-Stream-PowerTools.repo
+          yum localinstall -y glite-info-static-*.el8.noarch.rpm
+
+  # XXX Dependencies from EPEL: openldap-servers
+  centos9-install:
+    name: Install CentOS Stream 9 RPMs
+    needs: build
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream9
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: rpms9
+      - name: Install generated RPMs
+        run: |
+          yum install -y epel-release
+          yum localinstall -y glite-info-static-*.el9.noarch.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,13 +68,6 @@ jobs:
       - name: Install generated RPMs
         run: |
           yum localinstall -y glite-info-static-*.el7.noarch.rpm
-      - name: Test installed RPMs
-        run: |
-          curl https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo > /etc/yum.repos.d/EGI-trustanchors.repo
-          yum install -y ca-policy-egi-core
-          mkdir -p /etc/glite
-          echo 'capath = /etc/grid-security/certificates' >> /etc/glite/glite-info-static.conf
-          glite-info-static -v -c /etc/glite/glite-info-static.conf
 
   # Dependency from PowerTools: openldap-servers
   centos8-install:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           name: rpms7
           path: |
-            build/RPMS/noarch/glite-info-static-*-1.el7.noarch.rpm
+            build/RPMS/noarch/glite-info-static-*.el7.noarch.rpm
   install-centos7:
     name: Install CentOS 7 RPMs
     needs: build-centos7
@@ -72,7 +72,7 @@ jobs:
         with:
           name: rpms${{ matrix.centos-version }}
           path: |
-            build/RPMS/noarch/glite-info-static-*-1.el${{ matrix.centos-version }}.noarch.rpm
+            build/RPMS/noarch/glite-info-static-*.el${{ matrix.centos-version }}.noarch.rpm
   install:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+---
+name: Run tests
+
+on:
+  pull_request:
+
+jobs:
+  # XXX done outside of the matrix due to different container name
+  test-centos7:
+    name: Run tests on CentOS 7
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:7
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run tests
+        run: |
+          cd tests/
+          ./run-tests.sh
+
+  # Use a matrix for CentOS Stream versions
+  test:
+    strategy:
+      matrix:
+        centos-version: [8, 9]
+    name: Run tests on CentOS ${{ matrix.centos-version }}
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream${{ matrix.centos-version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run tests
+        run: |
+          cd tests/
+          ./run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
           fetch-depth: 0
       - name: Run tests
         run: |
+          yum install -y python3
           cd tests/
           ./run-tests.sh
 
@@ -33,5 +34,6 @@ jobs:
           fetch-depth: 0
       - name: Run tests
         run: |
+          yum install -y python3
           cd tests/
           ./run-tests.sh

--- a/glite-info-static.spec
+++ b/glite-info-static.spec
@@ -1,7 +1,7 @@
 Name: glite-info-static
 Version: 0.2.0
 Release: 2%{?dist}
-Summary: Core component for the glite-info-static framework.
+Summary: Core component for the static information framework
 Group: System/Monitoring
 License: ASL 2.0
 URL: https://github.com/EGI-Federation/glite-info-static
@@ -17,7 +17,8 @@ Requires: openldap-servers
 Requires: python3
 
 %description
-Core component for the glite-info-static framework.
+This application is an information provider that generates information
+in LDIF format from combining an LDIF template with configuration values.
 
 %prep
 %setup -q

--- a/glite-info-static.spec
+++ b/glite-info-static.spec
@@ -12,9 +12,9 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-build
 
 BuildRequires: rsync
 BuildRequires: make
-BuildRequires: python-rpm-macros
+BuildRequires: python3-rpm-macros
 Requires: openldap-servers
-Requires: python
+Requires: python3
 
 %description
 Core component for the glite-info-static framework.

--- a/sbin/glite-info-static
+++ b/sbin/glite-info-static
@@ -42,8 +42,8 @@ def usage():
     sys.stderr.write("Usage: %s -m <module> [OPTIONS] \n" % (sys.argv[0]))
     sys.stderr.write(
             """
-glite-info-create.sh -m <module> [-i <ifaces>] [-t <templates>] [-c <configs>]
-                                 [-p <path>] [-o <outpath>] [-d debug]
+glite-info-static -m <module> [-i <ifaces>] [-t <templates>] [-c <configs>]
+                              [-p <path>] [-o <outpath>] [-d debug]
 
 Parameters:
   -m <module>    The module you are using. E.g.: site
@@ -54,8 +54,8 @@ Parameters:
   -d <debug>     Debug level: 0:ERROR, 1:WARNING, 2:INFO, 3:DEBUG. Default: 0
 
 Examples:
-  glite-info-create.sh -m site
-  glite-info-create.sh -m site -i 'glue wlcg' -t glue2 -c /etc/site.cfg
+  glite-info-static -m site
+  glite-info-static -m site -i 'glue wlcg' -t glue2 -c /etc/site.cfg
 
 Web site: http://cern.ch/gridinfo
 """

--- a/sbin/glite-info-static
+++ b/sbin/glite-info-static
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 ##############################################################################
 # Copyright (c) Members of the EGEE Collaboration. 2010.
 # See http://www.eu-egee.org/partners/ for details on the copyright
@@ -29,18 +29,22 @@
 # WEB:          https://github.com/EGI-Federation/glite-info-static
 #
 ##############################################################################
-import os
-import sys
 import getopt
 import logging
+import os
+import sys
 
-# Funtion to print out the usage
+
 def usage():
-    sys.stderr.write('Usage: %s -m <module> [OPTIONS] \n' % (sys.argv[0]))
-    sys.stderr.write('''
-  glite-info-create.sh -m <module> [-i <ifaces>] [-t <templates>] [-c <configs>]
-                       [-p <path>] [-o <outpath>] [-d debug]
-       
+    """
+    Funtion to print out the usage
+    """
+    sys.stderr.write("Usage: %s -m <module> [OPTIONS] \n" % (sys.argv[0]))
+    sys.stderr.write(
+            """
+glite-info-create.sh -m <module> [-i <ifaces>] [-t <templates>] [-c <configs>]
+                                 [-p <path>] [-o <outpath>] [-d debug]
+
 Parameters:
   -m <module>    The module you are using. E.g.: site
   -i <ifaces>    The interface you want to use. E.g.: glue, wlcg (default)
@@ -54,66 +58,71 @@ Examples:
   glite-info-create.sh -m site -i 'glue wlcg' -t glue2 -c /etc/site.cfg
 
 Web site: http://cern.ch/gridinfo
-''')
+"""
+    )
+
 
 def parse_options():
     global config
 
     config = {}
-    config['debug'] = 0
-    config['ifaces'] = []
-    config['templates'] = []
-    config['path'] = '/etc/glite-info-static'
+    config["debug"] = 0
+    config["ifaces"] = []
+    config["templates"] = []
+    config["path"] = "/etc/glite-info-static"
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "i:t:c:m:p:d:h",
-          ["ifaces", "templates", "config", "module", "path", "debug", "help"])
+        opts, args = getopt.getopt(
+            sys.argv[1:],
+            "i:t:c:m:p:d:h",
+            ["ifaces", "templates", "config", "module", "path", "debug", "help"],
+        )
     except getopt.GetoptError:
         sys.stderr.write("Error: Invalid option specified.\n")
         usage()
         sys.exit(2)
     for o, a in opts:
         if o in ("-i", "--ifaces"):
-            config['ifaces'].append(a)
+            config["ifaces"].append(a)
         if o in ("-t", "--templates"):
-            config['templates'].append(a)
+            config["templates"].append(a)
         if o in ("-c", "--configs"):
-            config['config'] = a
+            config["config"] = a
         if o in ("-m", "--module"):
-            config['module'] = a
+            config["module"] = a
         if o in ("-p", "--path"):
-            config['path'] = a
+            config["path"] = a
         if o in ("-d", "--debug"):
-            config['debug'] = a
+            config["debug"] = a
         if o in ("-h", "--help"):
             usage()
             sys.exit(0)
 
     try:
-        config['debug'] = int(config['debug'])
-    except:
+        config["debug"] = int(config["debug"])
+    except ValueError:
         sys.stderr.write("Error: Invalid logging level.\n")
         usage()
         sys.exit(1)
-    if (config['debug'] > 3 or config['debug'] < 0 ):
+    if config["debug"] > 3 or config["debug"] < 0:
         sys.stderr.write("Error: Invalid logging level.\n")
         usage()
         sys.exit(1)
 
-    if ( not config.has_key('module') ):
+    if "module" not in config:
         sys.stderr.write("Error: Mandatory option -m <module> must be specified.\n")
         usage()
         sys.exit(1)
 
-    if ( not config.has_key('config') ):
+    if "config" not in config:
         sys.stderr.write("Error: Mandatory option -c <config> must be specified.\n")
         usage()
         sys.exit(1)
 
-    if ( len(config['ifaces']) == 0):
-        config['ifaces'] = ['glue','wlcg']
-    
-    if ( len(config['templates']) == 0):
-        config['templates'] = ['glue1','glue2']
+    if len(config["ifaces"]) == 0:
+        config["ifaces"] = ["glue", "wlcg"]
+
+    if len(config["templates"]) == 0:
+        config["templates"] = ["glue1", "glue2"]
 
     return
 
@@ -121,133 +130,136 @@ def parse_options():
 def main():
     global config, log
 
-    module = config['module']
+    module = config["module"]
 
     # Get key-values from the configuration file.
-    config_file="%s/%s/%s" %(config['path'], module, config['config'])   
-    if ( not os.path.exists(config_file) ):
-        log.error("Config file %s does not exist."%(config_file))
+    config_file = "%s/%s/%s" % (config["path"], module, config["config"])
+    if not os.path.exists(config_file):
+        log.error("Config file %s does not exist." % (config_file))
         sys.exit(1)
     parameters = {}
     for line in open(config_file).readlines():
-        index = line.find('=')
-        if ( index > 0 ):
+        index = line.find("=")
+        if index > 0:
             key = line[:index].strip()
-            value = line[index+1:].strip()
-            if ( not parameters.has_key(key) ):
+            value = line[index + 1 :].strip()
+            if key not in parameters:
                 parameters[key] = []
             parameters[key].append(value)
-            
+
     # Get the mandatory and optional attributes from the interface file.
-    for interface in config['ifaces']:
-        interface_file="%s/%s/%s.%s.ifc" %(config['path'], module, module, interface)   
-        if ( not os.path.exists(interface_file) ):
-            log.error("Interface file %s does not exist."%(interface_file))
+    for interface in config["ifaces"]:
+        interface_file = "%s/%s/%s.%s.ifc" % (config["path"], module, module, interface)
+        if not os.path.exists(interface_file):
+            log.error("Interface file %s does not exist." % (interface_file))
             sys.exit(1)
         interface_parameters = {}
         for line in open(interface_file).readlines():
-            index = line.find('=')
-            if ( index > 0 ):
+            index = line.find("=")
+            if index > 0:
                 key = line[:index].strip()
-                value = line[index+1:].strip()
-                if ( not value == ''):
+                value = line[index + 1 :].strip()
+                if not value == "":
                     values = value.split(" ")
                 else:
                     values = []
-                if ( not interface_parameters.has_key(key) ):
+                if key not in interface_parameters:
                     interface_parameters[key] = []
                 interface_parameters[key].extend(values)
 
     # Check the configuration file for the mandatory and optional attributes.
     mandatory_attributes = []
-    mandatory_attributes.extend(interface_parameters['MANDATORY_SINGLEVALUED_VARS'])
-    mandatory_attributes.extend(interface_parameters['MANDATORY_MULTIVALUED_VARS'])
+    mandatory_attributes.extend(interface_parameters["MANDATORY_SINGLEVALUED_VARS"])
+    mandatory_attributes.extend(interface_parameters["MANDATORY_MULTIVALUED_VARS"])
     for key in mandatory_attributes:
-        if ( parameters.has_key(key)):
+        if key in parameters:
             for value in parameters[key]:
-                if ( value == '' ):
-                    log.error('Mandatory atribute %s does not have a value.' %(key))
+                if value == "":
+                    log.error("Mandatory atribute %s does not have a value." % (key))
                     sys.exit(1)
         else:
-            log.error('Mandatory attribute %s is not specified in the configuration file' % (key))
+            log.error(
+                "Mandatory attribute %s is not specified in the configuration file"
+                % (key)
+            )
             sys.exit(1)
 
     optional_attributes = []
-    optional_attributes.extend(interface_parameters['OPTIONAL_SINGLEVALUED_VARS'])
+    optional_attributes.extend(interface_parameters["OPTIONAL_SINGLEVALUED_VARS"])
 
-    optional_attributes.extend(interface_parameters['OPTIONAL_MULTIVALUED_VARS'])
+    optional_attributes.extend(interface_parameters["OPTIONAL_MULTIVALUED_VARS"])
 
     for key in optional_attributes:
-        if ( parameters.has_key(key)):
+        if key in parameters:
             for value in parameters[key]:
-                if ( value  == '' ):
-                    log.error('Optional atribute %s does not have a value.' %(key))
+                if value == "":
+                    log.error("Optional atribute %s does not have a value." % (key))
                     sys.exit(1)
 
     # Check that single valued attributes are really single
     singlevalued_attributes = []
-    singlevalued_attributes.extend(interface_parameters['MANDATORY_SINGLEVALUED_VARS'])
-    singlevalued_attributes.extend(interface_parameters['OPTIONAL_SINGLEVALUED_VARS'])
+    singlevalued_attributes.extend(interface_parameters["MANDATORY_SINGLEVALUED_VARS"])
+    singlevalued_attributes.extend(interface_parameters["OPTIONAL_SINGLEVALUED_VARS"])
     for key in singlevalued_attributes:
-        if ( parameters.has_key(key)):
-            if ( len(parameters[key]) > 1 ):
-                log.error('Single valued atribute %s has more than one value.' %(key))
+        if key in parameters:
+            if len(parameters[key]) > 1:
+                log.error("Single valued atribute %s has more than one value." % (key))
                 sys.exit(1)
 
     ldif = ""
 
     # Get the default ldif from the template.
-    for template in config['templates']:
-        template_file = "%s/%s/%s.%s.tpl" %(config['path'], module, module, template) 
-        if ( not os.path.exists(template_file) ):
-            log.error("Template file %s does not exist."%(template_file))
+    for template in config["templates"]:
+        template_file = "%s/%s/%s.%s.tpl" % (config["path"], module, module, template)
+        if not os.path.exists(template_file):
+            log.error("Template file %s does not exist." % (template_file))
             sys.exit(1)
 
         ldif = open(template_file).read()
 
     multivalued_attributes = []
-    multivalued_attributes.extend(interface_parameters['MANDATORY_MULTIVALUED_VARS'])
-    multivalued_attributes.extend(interface_parameters['OPTIONAL_MULTIVALUED_VARS'])
+    multivalued_attributes.extend(interface_parameters["MANDATORY_MULTIVALUED_VARS"])
+    multivalued_attributes.extend(interface_parameters["OPTIONAL_MULTIVALUED_VARS"])
 
     # Do the substitution for single valued attributes
     for attribute in singlevalued_attributes:
         # If there is no value then delete the line, otherwise substitute it.
-        if ( parameters.has_key(attribute) ):
+        if attribute in parameters:
             for value in parameters[attribute]:
-                if ( not parameters[attribute] == ''):
-                    ldif = ldif.replace('$'+attribute, value)
+                if not parameters[attribute] == "":
+                    ldif = ldif.replace("$" + attribute, value)
             else:
-                ldif = ldif.replace('$'+attribute, '')
+                ldif = ldif.replace("$" + attribute, "")
         else:
-            ldif = ldif.replace('$'+attribute, '')
+            ldif = ldif.replace("$" + attribute, "")
 
     # Do the substitution for multivalued attributes
     for attribute in multivalued_attributes:
         # If there is no value then delete the line, otherwise substitute it.
-        if ( parameters.has_key(attribute) ):
-            end = ldif.find('$'+attribute)
-            start = ldif[:end].rfind('\n') + 1
+        if attribute in parameters:
+            end = ldif.find("$" + attribute)
+            start = ldif[:end].rfind("\n") + 1
             glue_attribute = ldif[start:end]
             chunk = ""
             for value in parameters[attribute]:
-                if ( not parameters[attribute] == ''):
-                    chunk += glue_attribute + value + '\n'
-            ldif = ldif.replace(glue_attribute+'$'+attribute, chunk[:-1])
+                if not parameters[attribute] == "":
+                    chunk += glue_attribute + value + "\n"
+            ldif = ldif.replace(glue_attribute + "$" + attribute, chunk[:-1])
         else:
-            ldif = ldif.replace('$'+attribute, '')
+            ldif = ldif.replace("$" + attribute, "")
 
-    print ldif
+    print(ldif)
 
 
 if __name__ == "__main__":
     global config, log
-         
+
     parse_options()
 
-    log = logging.getLogger('%s' %(sys.argv[0]))
+    log = logging.getLogger("%s" % (sys.argv[0]))
     hdlr = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('[%(levelname)s]: %(message)s')
+    formatter = logging.Formatter("[%(levelname)s]: %(message)s")
     hdlr.setFormatter(formatter)
     log.addHandler(hdlr)
-    log.setLevel(config['debug'])
+    log.setLevel(config["debug"])
     main()

--- a/sbin/glite-info-static
+++ b/sbin/glite-info-static
@@ -42,7 +42,7 @@ def usage():
     sys.stderr.write("Usage: %s -m <module> [OPTIONS] \n" % (sys.argv[0]))
     sys.stderr.write(
             """
-glite-info-static -m <module> [-i <ifaces>] [-t <templates>] [-c <configs>]
+glite-info-static -m <module> [-i <ifaces>] [-t <templates>] [-c <config>]
                               [-p <path>] [-o <outpath>] [-d debug]
 
 Parameters:
@@ -85,7 +85,7 @@ def parse_options():
             config["ifaces"].append(a)
         if o in ("-t", "--templates"):
             config["templates"].append(a)
-        if o in ("-c", "--configs"):
+        if o in ("-c", "--config"):
             config["config"] = a
         if o in ("-m", "--module"):
             config["module"] = a

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 working_dir=$(pwd)
 script=${working_dir}/../sbin/glite-info-static 
@@ -8,8 +8,7 @@ RETVAL=0
 command="${script} -p ${module_dir} -m site -c my_site.cfg -i glue -t glue1"
 
 echo -n "Tesing provinding output ... "
-${command} | grep "objectClass: GlueSite"  >/dev/null
-if [ $? -eq 0 ]; then
+if ${command} | grep -q "objectClass: GlueSite"; then
     echo "OK"
 else
     echo "FAIL"
@@ -17,8 +16,8 @@ else
 fi
 
 echo -n "Tesing single value substitution ... "
-num=$(${command} | grep "GlueSiteOtherInfo" | wc -l )
-if [ ${num} -eq 2 ]; then
+num=$(${command} | grep -c "GlueSiteOtherInfo")
+if [ "${num}" -eq 2 ]; then
     echo "OK"
 else
     echo "FAIL"
@@ -26,8 +25,7 @@ else
 fi
 
 echo -n "Tesing multi value substitution ... "
-${command} | grep "GlueSiteUniqueID: cern.ch"  >/dev/null
-if [ $? -eq 0 ]; then
+if ${command} | grep -q "GlueSiteUniqueID: cern.ch"; then
     echo "OK"
 else
     echo "FAIL"


### PR DESCRIPTION
- Address errors from python and shell linters
- Add a GitHub Action worfklow to run provided test file (it maybe easier/cleaner to use something like https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python)
- Port script to python3

Close #4